### PR TITLE
fix: typo in listernerMiddleware

### DIFF
--- a/src/redux/middleware.js
+++ b/src/redux/middleware.js
@@ -23,7 +23,7 @@ export const logger = ({ getState }) => (next) => (action) => {
   return returnValue
 }
 
-export const listernerMiddleware = (listener) => ({ getState }) => (next) => (
+export const listenerMiddleware = (listener) => ({ getState }) => (next) => (
   action
 ) => {
   const { key } = action.payload
@@ -33,3 +33,8 @@ export const listernerMiddleware = (listener) => ({ getState }) => (next) => (
   listener(getState().main, key, prevValue, nextValue)
   return value
 }
+
+/**
+ * @deprecated Use listenerMiddleware
+ */
+export const listernerMiddleware = listenerMiddleware

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,12 +1,12 @@
 import { createStore, applyMiddleware } from 'redux'
 import rootReducer from './reducer'
-import { logger, listernerMiddleware } from './middleware'
+import { logger, listenerMiddleware } from './middleware'
 
 export default function storeCreator(initialValue = {}, config = {}) {
   const { logging, listener } = config
 
   const middlewares = [
-    listener && listernerMiddleware(listener),
+    listener && listenerMiddleware(listener),
     logging && logger
   ].filter(Boolean)
 


### PR DESCRIPTION
Old const is reexported for BC and should be remove in next major.