### PR TITLE
build: add ability to create typescript definitions

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -1,5 +1,6 @@
 yarn test && \
 yarn build && \
+yarn declaration:build && \
 yarn prepare && \
 yarn predeploy && \
 yarn deploy && \

--- a/declaration.tsconfig.json
+++ b/declaration.tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig",
+  "exclude": [
+    "src/__tests__/**/*"
+  ],
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "module": "dist/index.es.js",
   "unpkg": "dist/react-context-hook.js",
   "jsnext:main": "dist/index.es.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -36,7 +37,8 @@
     "release": "standard-version",
     "prettier": "prettier --write 'src/**/*.js' 'example/**/*.css' 'example/**/*.html' 'example/src/**/*.js'",
     "docs:build": "documentation build src/** -f html -o docs",
-    "docs:buildmd": "documentation build src/** -f md -o DOCS.md"
+    "docs:buildmd": "documentation build src/** -f md -o DOCS.md",
+    "declaration:build": "rm -f dist/index.d.ts && tsc -p declaration.tsconfig.json"
   },
   "peerDependencies": {
     "react": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "prettier --write 'src/**/*.js' 'example/**/*.css' 'example/**/*.html' 'example/src/**/*.js'",
     "docs:build": "documentation build src/** -f html -o docs",
     "docs:buildmd": "documentation build src/** -f md -o DOCS.md",
-    "declaration:build": "rm -f dist/index.d.ts && tsc -p declaration.tsconfig.json"
+    "declaration:build": "rm -f dist/*.d.ts && tsc -p declaration.tsconfig.json"
   },
   "peerDependencies": {
     "react": "^17.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "include": [
+    "src/**/*"
+  ],
+  "compilerOptions": {
+    "target": "es5",
+    "module": "esnext",
+    "allowJs": true,
+    "outDir": "./dist",
+    "strict": true,
+    "moduleResolution": "node",
+    "baseUrl": "./src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
This PR adds the necessary build step to create typescript definitions for the hooks.

The build script in package.json will currently need to be manually called, but can be added to the correct build script to automate.

fixes #2